### PR TITLE
upgrade ember-cli-htmlbars to 1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-htmlbars": "0.7.6"
+    "ember-cli-htmlbars": "^1.0.1"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
Current version will break app build on windows once broccolijs/broccoli-merge-trees#31 is merged
Upgrade ember-cli-htmlbars to latest version fixed the issue

cc @stefanpenner